### PR TITLE
Include license file in source distribution

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,2 +1,3 @@
 include versioneer.py
 include pymove/_version.py
+include LICENSE


### PR DESCRIPTION
This PR makes it so the license file is included in the source distribution as one might interpret is a requirement of the MIT license. 