### PR TITLE
Renaming visualization methods 

### DIFF
--- a/pymove/tests/test_visualization_folium.py
+++ b/pymove/tests/test_visualization_folium.py
@@ -460,7 +460,7 @@ def test_filter_generated_feature():
         pass
 
 
-def test_add_begin_end_markers_to_folium_map(tmpdir):
+def test_add_begin_end_markers_to_map(tmpdir):
 
     move_df = _default_move_df()
 
@@ -471,7 +471,7 @@ def test_add_begin_end_markers_to_folium_map(tmpdir):
         tile=TILES[0],
         default_zoom_start=12)
 
-    folium._add_begin_end_markers_to_folium_map(move_df, base_map)
+    folium._add_begin_end_markers_to_map(move_df, base_map)
 
     d = tmpdir.mkdir('visualization')
 
@@ -518,7 +518,7 @@ def test_add_begin_end_markers_to_folium_map(tmpdir):
                 '\n{"clusteredMarker":true,"color":"red"}') in map_info)
 
 
-def test_add_trajectories_to_folium_map(tmpdir):
+def test_add_trajectories_to_map(tmpdir):
     move_df = _default_move_df()
 
     d = tmpdir.mkdir('visualization')
@@ -580,18 +580,18 @@ def test_add_trajectories_to_folium_map(tmpdir):
     )
 
 
-def test_plot_trajectories_with_folium(tmpdir):
+def test_plot_trajectories(tmpdir):
 
     move_df = _default_move_df()
 
     d = tmpdir.mkdir('visualization')
 
-    file_write_default = d.join('plot_trajectories_with_folium.html')
+    file_write_default = d.join('plot_trajectories.html')
     filename = os.path.join(
         file_write_default.dirname, file_write_default.basename
     )
 
-    base_map = folium.plot_trajectories_with_folium(
+    base_map = folium.plot_trajectories(
         move_df,
         n_rows=3,
         save_as_html=True,
@@ -645,18 +645,18 @@ def test_plot_trajectories_with_folium(tmpdir):
     )
 
 
-def test_plot_trajectory_by_id_folium(tmpdir):
+def test_plot_trajectory_by_id(tmpdir):
 
     move_df = _default_move_df()
 
     d = tmpdir.mkdir('visualization')
 
-    file_write_default = d.join('plot_trajectory_by_id_folium.html')
+    file_write_default = d.join('plot_trajectory_by_id.html')
     filename_write_default = os.path.join(
         file_write_default.dirname, file_write_default.basename
     )
 
-    base_map = folium.plot_trajectory_by_id_folium(
+    base_map = folium.plot_trajectory_by_id(
         move_df,
         id_=1,
         save_as_html=True,
@@ -866,18 +866,18 @@ def test_plot_bbox(tmpdir):
     assert_equal(expected, actual)
 
 
-def test_plot_point_folium(tmpdir):
+def test_plot_point(tmpdir):
 
     move_df = _default_move_df()
 
     d = tmpdir.mkdir('visualization')
 
-    file_write_default = d.join('plot_point_folium.html')
+    file_write_default = d.join('plot_point.html')
     filename = os.path.join(
         file_write_default.dirname, file_write_default.basename
     )
 
-    base_map = folium.plot_points_folium(
+    base_map = folium.plot_points(
         move_data=move_df,
         user_lat=LATITUDE,
         user_lon=LONGITUDE,
@@ -936,18 +936,18 @@ def test_plot_point_folium(tmpdir):
     )
 
 
-def test_plot_poi_folium(tmpdir):
+def test_plot_poi(tmpdir):
 
     move_df = _default_move_df()
 
     d = tmpdir.mkdir('visualization')
 
-    file_write_default = d.join('plot_point_folium.html')
+    file_write_default = d.join('plot_point.html')
     filename = os.path.join(
         file_write_default.dirname, file_write_default.basename
     )
 
-    base_map = folium.plot_poi_folium(
+    base_map = folium.plot_poi(
         move_data=move_df,
         poi_lat=LATITUDE,
         poi_lon=LONGITUDE,
@@ -1005,18 +1005,18 @@ def test_plot_poi_folium(tmpdir):
     )
 
 
-def test_plot_event_folium(tmpdir):
+def test_plot_event(tmpdir):
 
     move_df = _default_move_df()
 
     d = tmpdir.mkdir('visualization')
 
-    file_write_default = d.join('plot_event_folium.html')
+    file_write_default = d.join('plot_event.html')
     filename = os.path.join(
         file_write_default.dirname, file_write_default.basename
     )
 
-    base_map = folium.plot_event_folium(
+    base_map = folium.plot_event(
         move_data=move_df,
         event_lat=LATITUDE,
         event_lon=LONGITUDE,

--- a/pymove/tests/test_visualization_matplotlib.py
+++ b/pymove/tests/test_visualization_matplotlib.py
@@ -50,7 +50,8 @@ def test_show_object_id_by_date(tmpdir):
 
     mpl.show_object_id_by_date(
         move_data=move_df,
-        name=filename_write_default
+        name=filename_write_default,
+        save_fig=True
     )
 
     test_dir = os.path.abspath(os.path.dirname(__file__))
@@ -64,7 +65,7 @@ def test_show_object_id_by_date(tmpdir):
     )
 
 
-def test_plot_traj_by_id(tmpdir):
+def test_plot_trajectory_by_id(tmpdir):
     move_df = _default_move_df()
     move_df[TID] = ['1', '1', '2', '2', '2']
 
@@ -75,7 +76,7 @@ def test_plot_traj_by_id(tmpdir):
         file_write_default.dirname, file_write_default.basename
     )
 
-    mpl.plot_traj_by_id(move_df, '1', save_fig=True, name=filename_write_default)
+    mpl.plot_trajectory_by_id(move_df, '1', save_fig=True, name=filename_write_default)
 
     test_dir = os.path.abspath(os.path.dirname(__file__))
     data_dir = os.path.join(test_dir, 'baseline/traj_id.png')

--- a/pymove/visualization/folium.py
+++ b/pymove/visualization/folium.py
@@ -8,17 +8,17 @@ heatmap_with_time,
 cluster,
 faster_cluster,
 plot_markers,
-plot_trajectories_with_folium,
-plot_trajectory_by_id_folium,
+plot_trajectories,
+plot_trajectory_by_id,
 plot_trajectory_by_period,
 plot_trajectory_by_day_week,
 plot_trajectory_by_date,
 plot_trajectory_by_hour,
 plot_stops,
 plot_bbox,
-plot_points_folium,
-plot_poi_folium,
-plot_event_folium,
+plot_points,
+plot_poi,
+plot_event,
 plot_traj_timestamp_geo_json
 
 """
@@ -792,7 +792,7 @@ def _filter_generated_feature(
     return mv_df
 
 
-def _add_begin_end_markers_to_folium_map(
+def _add_begin_end_markers_to_map(
     move_data: DataFrame,
     base_map: Map,
     color: Optional[Text] = None,
@@ -817,7 +817,7 @@ def _add_begin_end_markers_to_folium_map(
 
     Examples
     --------
-    >>> from pymove.visualization.folium import _add_begin_end_markers_to_folium_map
+    >>> from pymove.visualization.folium import _add_begin_end_markers_to_map
     >>> move_df.head()
               lat          lon              datetime   id
     0   39.984094   116.319236   2008-10-23 05:53:05    1
@@ -826,7 +826,7 @@ def _add_begin_end_markers_to_folium_map(
     3   39.984211   116.319389   2008-10-23 05:53:16    1
     4   39.984217   116.319422   2008-10-23 05:53:21    1
     >>> map = create_base_map(move_df)
-    >>> _add_begin_end_markers_to_folium_map(move_df, map)
+    >>> _add_begin_end_markers_to_map(move_df, map)
     """
     points = folium.map.FeatureGroup(
         'The start and end points of trajectory {}'.format(_id or '')
@@ -855,7 +855,7 @@ def _add_begin_end_markers_to_folium_map(
     base_map.add_child(points)
 
 
-def _add_trajectories_to_folium_map(
+def _add_trajectories_to_map(
     move_data: DataFrame,
     items: Sequence[Tuple],
     base_map: Map,
@@ -881,14 +881,14 @@ def _add_trajectories_to_folium_map(
 
     Examples
     --------
-    >>> from pymove.visualization.folium import _add_trajectories_to_folium_map
+    >>> from pymove.visualization.folium import _add_trajectories_to_map
     >>> move_df
                    lat          lon              datetime   id
     0        39.984094   116.319236   2008-10-23 05:53:05    1
     1        39.984198   116.319322   2008-10-23 05:53:06    1
     3        39.988118   116.326672   2008-10-25 14:39:19    5
     4        39.987965   116.326675   2008-10-25 14:39:24    5
-    >>> _add_trajectories_to_folium_map(
+    >>> _add_trajectories_to_map(
     >>>    move_data=move_df,
     >>>    base_map=map1,
     >>>    items=[(1, 'red'), [5, 'green']]
@@ -897,7 +897,7 @@ def _add_trajectories_to_folium_map(
     for _id, color in items:
         mv = move_data[move_data[TRAJ_ID] == _id]
 
-        _add_begin_end_markers_to_folium_map(mv, base_map, color, _id)
+        _add_begin_end_markers_to_map(mv, base_map, color, _id)
 
         folium.PolyLine(
             mv[[LATITUDE, LONGITUDE]], color=color, weight=2.5, opacity=1
@@ -912,7 +912,7 @@ def _add_trajectories_to_folium_map(
         base_map.save(outfile=filename)
 
 
-def plot_trajectories_with_folium(
+def plot_trajectories(
     move_data: DataFrame,
     n_rows: Optional[int] = None,
     lat_origin: Optional[float] = None,
@@ -924,7 +924,7 @@ def plot_trajectories_with_folium(
     save_as_html: bool = False,
     color: Optional[Union[Text, List[Text]]] = None,
     color_by_id: Optional[Dict] = None,
-    filename: Text = 'plot_trajectories_with_folium.html',
+    filename: Text = 'plot_trajectories.html',
 ) -> Map:
     """
     Generate visualization of all trajectories with folium.
@@ -961,7 +961,7 @@ def plot_trajectories_with_folium(
         by default None.
     filename : str, optional
         Represents the file name of new file .html,
-        by default 'plot_trajectory_with_folium.html'.
+        by default 'plot_trajectory.html'.
 
     Returns
     -------
@@ -970,7 +970,7 @@ def plot_trajectories_with_folium(
 
     Examples
     --------
-    >>>  from pymove.visualization.folium import plot_trajectories_with_folium
+    >>>  from pymove.visualization.folium import plot_trajectories
     >>> move_df.head()
               lat          lon              datetime   id
     0   39.984094   116.319236   2008-10-23 05:53:05    1
@@ -978,7 +978,7 @@ def plot_trajectories_with_folium(
     2   39.984224   116.319402   2008-10-23 05:53:11    1
     3   39.984211   116.319389   2008-10-23 05:53:16    1
     4   39.984217   116.319422   2008-10-23 05:53:21    1
-    >>> plot_trajectories_with_folium(move_df)
+    >>> plot_trajectories(move_df)
     """
     if base_map is None:
         base_map = create_base_map(
@@ -993,14 +993,14 @@ def plot_trajectories_with_folium(
         move_data, n_rows=n_rows, color=color, color_by_id=color_by_id
     )
 
-    _add_trajectories_to_folium_map(
+    _add_trajectories_to_map(
         mv_df, items, base_map, legend, save_as_html, filename
     )
 
     return base_map
 
 
-def plot_trajectory_by_id_folium(
+def plot_trajectory_by_id(
     move_data: DataFrame,
     id_: int,
     n_rows: Optional[int] = None,
@@ -1012,7 +1012,7 @@ def plot_trajectory_by_id_folium(
     tile: Text = TILES[0],
     save_as_html: bool = False,
     color: Optional[Union[Text, List[Text]]] = None,
-    filename: Text = 'plot_trajectories_with_folium.html',
+    filename: Text = 'plot_trajectories.html',
 ) -> Map:
     """
     Generate visualization of all trajectories with folium.
@@ -1048,7 +1048,7 @@ def plot_trajectory_by_id_folium(
         Can be a single color name, a list of colors or a colormap name, by default None.
     filename : str, optional
         Represents the file name of new file .html,
-        by default 'plot_trajectory_by_id_with_folium.html'.
+        by default 'plot_trajectory_by_id.html'.
 
     Returns
     -------
@@ -1062,7 +1062,7 @@ def plot_trajectory_by_id_folium(
 
     Examples
     --------
-    >>> from pymove.visualization.folium import plot_trajectory_by_id_folium
+    >>> from pymove.visualization.folium import plot_trajectory_by_id
     >>> move_df.head()
               lat          lon              datetime   id
     0   39.984094   116.319236   2008-10-23 05:53:05    1
@@ -1070,7 +1070,7 @@ def plot_trajectory_by_id_folium(
     2   39.984224   116.319402   2008-10-23 05:53:11    1
     3   39.984211   116.319389   2008-10-23 05:53:16    2
     4   39.984217   116.319422   2008-10-23 05:53:21    2
-    >>> plot_trajectory_by_id_folium(move_df, id_=1)
+    >>> plot_trajectory_by_id(move_df, id_=1)
     """
     if base_map is None:
         base_map = create_base_map(
@@ -1082,7 +1082,7 @@ def plot_trajectory_by_id_folium(
         )
 
     mv_df, items = _filter_and_generate_colors(move_data, id_, n_rows, color)
-    _add_trajectories_to_folium_map(
+    _add_trajectories_to_map(
         mv_df, items, base_map, legend, save_as_html, filename
     )
 
@@ -1185,7 +1185,7 @@ def plot_trajectory_by_period(
 
     mv_df = _filter_generated_feature(move_data, PERIOD, [period])
     mv_df, items = _filter_and_generate_colors(mv_df, id_, n_rows, color, color_by_id)
-    _add_trajectories_to_folium_map(
+    _add_trajectories_to_map(
         mv_df, items, base_map, legend, save_as_html, filename
     )
     to_drop = list(set(move_data.columns) - set(columns))
@@ -1290,7 +1290,7 @@ def plot_trajectory_by_day_week(
 
     mv_df = _filter_generated_feature(move_data, DAY, [day_week])
     mv_df, items = _filter_and_generate_colors(mv_df, id_, n_rows, color, color_by_id)
-    _add_trajectories_to_folium_map(
+    _add_trajectories_to_map(
         mv_df, items, base_map, legend, save_as_html, filename
     )
     to_drop = list(set(move_data.columns) - set(columns))
@@ -1408,7 +1408,7 @@ def plot_trajectory_by_date(
 
     mv_df = _filter_generated_feature(move_data, DATE, [start_date, end_date])
     mv_df, items = _filter_and_generate_colors(mv_df, id_, n_rows, color, color_by_id)
-    _add_trajectories_to_folium_map(
+    _add_trajectories_to_map(
         mv_df, items, base_map, legend, save_as_html, filename
     )
     to_drop = list(set(move_data.columns) - set(columns))
@@ -1516,7 +1516,7 @@ def plot_trajectory_by_hour(
 
     mv_df = _filter_generated_feature(move_data, HOUR, [start_hour, end_hour])
     mv_df, items = _filter_and_generate_colors(mv_df, id_, n_rows, color, color_by_id)
-    _add_trajectories_to_folium_map(
+    _add_trajectories_to_map(
         mv_df, items, base_map, legend, save_as_html, filename
     )
     to_drop = list(set(move_data.columns) - set(columns))
@@ -1723,7 +1723,7 @@ def _format_tags(line: Union[List, Dict], slice_: List) -> Text:
 
     Examples
     --------
-    >>> from pymove.visualization.folium import _format_tags, plot_points_folium
+    >>> from pymove.visualization.folium import _format_tags, plot_points
     >>> move_df.head()
               lat          lon              datetime   id
     0   39.984094   116.319236   2008-10-23 05:53:05    1
@@ -1812,7 +1812,7 @@ def _circle_maker(
     ).add_to(map_)
 
 
-def plot_points_folium(
+def plot_points(
     move_data: DataFrame,
     user_lat: Text = LATITUDE,
     user_lon: Text = LONGITUDE,
@@ -1859,7 +1859,7 @@ def plot_points_folium(
 
     Examples
     --------
-    >>> from pymove.visualization.folium import plot_points_folium
+    >>> from pymove.visualization.folium import plot_points
     >>> move_df.head()
               lat          lon              datetime   id
     0   39.984094   116.319236   2008-10-23 05:53:05    1
@@ -1867,7 +1867,7 @@ def plot_points_folium(
     2   39.984224   116.319402   2008-10-23 05:53:11    1
     3   39.984211   116.319389   2008-10-23 05:53:16    1
     4   39.984217   116.319422   2008-10-23 05:53:21    1
-    >>> plot_points_folium(move_df)
+    >>> plot_points(move_df)
     """
     if slice_tags is None:
         slice_tags = list(move_data.columns)
@@ -1899,7 +1899,7 @@ def plot_points_folium(
     return base_map
 
 
-def plot_poi_folium(
+def plot_poi(
     move_data: DataFrame,
     poi_lat: Text = LATITUDE,
     poi_lon: Text = LONGITUDE,
@@ -1944,7 +1944,7 @@ def plot_poi_folium(
 
     Examples
     --------
-    >>> from pymove.visualization.folium import plot_poi_folium
+    >>> from pymove.visualization.folium import plot_poi
     >>> move_df.head()
               lat          lon              datetime   id
     0   39.984094   116.319236   2008-10-23 05:53:05    1
@@ -1952,9 +1952,9 @@ def plot_poi_folium(
     2   39.984224   116.319402   2008-10-23 05:53:11    1
     3   39.984211   116.319389   2008-10-23 05:53:16    1
     4   39.984217   116.319422   2008-10-23 05:53:21    1
-    >>> plot_poi_folium(move_df)
+    >>> plot_poi(move_df)
     """
-    return plot_points_folium(
+    return plot_points(
         move_data,
         user_lat=poi_lat,
         user_lon=poi_lon,
@@ -1968,7 +1968,7 @@ def plot_poi_folium(
     )
 
 
-def plot_event_folium(
+def plot_event(
     move_data: DataFrame,
     event_lat: Text = LATITUDE,
     event_lon: Text = LONGITUDE,
@@ -2010,7 +2010,7 @@ def plot_event_folium(
 
     Examples
     --------
-    >>> from pymove.visualization.folium import plot_event_folium
+    >>> from pymove.visualization.folium import plot_event
     >>> move_df.head()
               lat          lon              datetime   id
     0   39.984094   116.319236   2008-10-23 05:53:05    1
@@ -2018,9 +2018,9 @@ def plot_event_folium(
     2   39.984224   116.319402   2008-10-23 05:53:11    1
     3   39.984211   116.319389   2008-10-23 05:53:16    1
     4   39.984217   116.319422   2008-10-23 05:53:21    1
-    >>> plot_event_folium(move_df)
+    >>> plot_event(move_df)
     """
-    return plot_points_folium(
+    return plot_points(
         move_data,
         user_lat=event_lat,
         user_lon=event_lon,

--- a/pymove/visualization/matplotlib.py
+++ b/pymove/visualization/matplotlib.py
@@ -3,7 +3,7 @@ Matplolib operations.
 
 show_object_id_by_date,
 plot_trajectories,
-plot_traj_by_id,
+plot_trajectory_by_id,
 plot_all_features
 plot_coords,
 plot_bounds,
@@ -39,8 +39,8 @@ def show_object_id_by_date(
     move_data: Union['PandasMoveDataFrame', 'DaskMoveDataFrame'],
     kind: Optional[List] = None,
     figsize: Tuple[float, float] = (21, 9),
-    return_fig: bool = True,
-    save_fig: bool = True,
+    return_fig: bool = False,
+    save_fig: bool = False,
     name: Text = 'shot_points_by_date.png',
 ) -> Optional[figure]:
     """
@@ -60,9 +60,9 @@ def show_object_id_by_date(
     figsize : tuple, optional
         Represents dimensions of figure, by default (21,9).
     return_fig : bool, optional
-        Represents whether or not to save the generated picture, by default True.
+        Represents whether or not to save the generated picture, by default False.
     save_fig : bool, optional
-        Represents whether or not to save the generated picture, by default True.
+        Represents whether or not to save the generated picture, by default False.
     name : String, optional
         Represents name of a file, by default 'shot_points_by_date.png'.
 
@@ -131,8 +131,8 @@ def plot_trajectories(
     markers: Text = 'o',
     markersize: float = 12,
     figsize: Tuple[float, float] = (10, 10),
-    return_fig: bool = True,
-    save_fig: bool = True,
+    return_fig: bool = False,
+    save_fig: bool = False,
     name: Text = 'trajectories.png',
 ) -> Optional[figure]:
     """
@@ -149,7 +149,7 @@ def plot_trajectories(
     figsize : tuple(float, float), optional
             Represents dimensions of figure, by default (10, 10)
     return_fig : bool, optional
-        Represents whether or not to return the generated picture, by default True
+        Represents whether or not to return the generated picture, by default False
     save_fig : bool, optional
         Represents whether or not to save the generated picture, by default False
     name : str, optional
@@ -191,7 +191,7 @@ def plot_trajectories(
         return fig
 
 
-def plot_traj_by_id(
+def plot_trajectory_by_id(
     move_data: DataFrame,
     id_: Union[int, Text],
     label: Text = TID,
@@ -200,8 +200,8 @@ def plot_traj_by_id(
     linewidth: float = 3,
     markersize: float = 20,
     figsize: Tuple[float, float] = (10, 10),
-    return_fig: bool = True,
-    save_fig: bool = True,
+    return_fig: bool = False,
+    save_fig: bool = False,
     name: Optional[Text] = None,
 ) -> Optional[figure]:
     """
@@ -226,7 +226,7 @@ def plot_traj_by_id(
     figsize : tuple(float, float), optional
         Represents dimensions of figure, by default (10, 10)
     return_fig : bool, optional
-        Represents whether or not to return the generated picture, by default True
+        Represents whether or not to return the generated picture, by default False
     save_fig : bool, optional
         Represents whether or not to save the generated picture, by default False
     name : str, optional
@@ -306,8 +306,8 @@ def plot_all_features(
     move_data: DataFrame,
     dtype: Callable = float,
     figsize: Tuple[float, float] = (21, 15),
-    return_fig: bool = True,
-    save_fig: bool = True,
+    return_fig: bool = False,
+    save_fig: bool = False,
     name: Text = 'features.png',
 ) -> Optional[figure]:
     """
@@ -322,7 +322,7 @@ def plot_all_features(
     figsize : tuple(float, float), optional
         Represents dimensions of figure, by default (21, 15)
     return_fig : bool, optional
-        Represents whether or not to return the generated picture, by default True
+        Represents whether or not to return the generated picture, by default False
     save_fig : bool, optional
         Represents whether or not to save the generated picture, by default False
     name : str, optional


### PR DESCRIPTION
## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
-   [ ] Bug fix (non-breaking change which fixes an issue)
-   [ ] New feature (non-breaking change which adds functionality)
-   [ ] Breaking change (fix or feature that would cause existing functionality to change)
-   [ ] I have read the **CONTRIBUTING** document.
-   [x] My code follows the code style of this project (see `.code-style.md`).
-   [x] All new and existing tests passed (see `.testing.md`).
-   [ ] I have added tests to cover my changes.
-   [ ] My change requires a change to the documentation.
-   [ ] I have updated the documentation accordingly (see `.documentation.md`).

## Description

-   What is the current behavior? (You can also link to an open issue here)
In this pull, I updated the name of the methods that used folium in its names and it was like a redundant word.
